### PR TITLE
[AV-3601] Initialise ivars after lock and do not execute decisions/entries if finished

### DIFF
--- a/lib/decision_tree/version.rb
+++ b/lib/decision_tree/version.rb
@@ -1,3 +1,3 @@
 module DecisionTree
-  VERSION = "0.1.0"
+  VERSION = "0.1.1"
 end


### PR DESCRIPTION
When the _store_ yields inside a _with_lock_ call, subsequent requests will block until the lock is available. At that time the object will be reloaded. However, the previous implementation in `decision_tree` set the ivars before calling `start_workflow`. This led to the ivars holding values from the original instantiation of the store and incorrectly processing against those. They need to be set after the _store_ object has been reloaded.

Also, I've had to put in early returns to stop decisions and entry points from being run after the workflow has already finished.