### PR TITLE
Update ruby version in buildkite script to 2.1.5

### DIFF
--- a/script/buildkite.sh
+++ b/script/buildkite.sh
@@ -2,7 +2,7 @@
 set -e
 
 echo '--- setting ruby version'
-rbenv local 2.1.3
+rbenv local 2.1.5
 
 echo '--- bundling'
 bundle install -j $(nproc) --without production --quiet


### PR DESCRIPTION
Apparently 2.1.3 is no longer available on our buildkite agents