### PR TITLE
Update ruby version in buildkite script to 2.2.2

### DIFF
--- a/script/buildkite.sh
+++ b/script/buildkite.sh
@@ -2,7 +2,10 @@
 set -e
 
 echo '--- setting ruby version'
-rbenv local 2.1.3
+rbenv install -s 2.2.2
+rbenv local 2.2.2
+rbenv rehash
+gem install bundler --no-rdoc --no-ri
 
 echo '--- bundling'
 bundle install -j $(nproc) --without production --quiet


### PR DESCRIPTION
Ruby 2.2.2 is not installed by default on the JobReady buildkite setup so I have updated the build script to install it.

Ruby 2.2.2 is needed if using Activesupport 5+